### PR TITLE
Feat: Plugin cleanup

### DIFF
--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -1037,33 +1037,6 @@ void SendHudMsg(
 	}
 }
 
-stock void PrintHintTextRGB(int client, const char[] format, any ...)
-{
-	char buff[2048];
-	VFormat(buff, sizeof(buff), format, 3);
-	FormatEx(buff, sizeof(buff), "</font>%s ", buff);
-
-	for (int i = strlen(buff); i < sizeof(buff); i++)
-	{
-		buff[i] = ' ';
-	}
-
-	Handle hMessage = StartMessageOne("TextMsg", client, USERMSG_RELIABLE);
-
-	if (hMessage != INVALID_HANDLE)
-	{
-		PbSetInt(hMessage, "msg_dst", 4);
-		PbAddString(hMessage, "params", "#SFUI_ContractKillStart");
-		PbAddString(hMessage, "params", buff);
-		PbAddString(hMessage, "params", NULL_STRING);
-		PbAddString(hMessage, "params", NULL_STRING);
-		PbAddString(hMessage, "params", NULL_STRING);
-		PbAddString(hMessage, "params", NULL_STRING);
-
-		EndMessage();
-	}
-}
-
 public void BuildName(CBoss boss, char[] szName, int maxlen)
 {
 	CConfig config = boss.dConfig;

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -70,7 +70,7 @@ public Plugin myinfo = {
 	name = "BossHUD",
 	author = "AntiTeal, Cloud Strife, maxime1907",
 	description = "Show the health of bosses and breakables",
-	version = "3.6.8",
+	version = "3.7",
 	url = "antiteal.com"
 };
 

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -11,10 +11,6 @@
 #include <LagReducer>
 #include <multicolors>
 
-#undef REQUIRE_PLUGIN
-#tryinclude <DynamicChannels>
-#define REQUIRE_PLUGIN
-
 #pragma newdecls required
 
 #define MAX_TEXT_LENGTH	64

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -572,10 +572,7 @@ public void LagReducer_OnStartGameFrame()
 public void LagReducer_OnClientGameFrame(int iClient)
 {
 	if (g_sHUDTextSave[0] && IsValidClient(iClient) && g_bShowHealth[iClient])
-	{
-		if (IsValidClient(iClient) && g_bShowHealth[iClient])
-			SendHudMsg(iClient, g_sHUDTextSave, g_iDisplayType, INVALID_HANDLE, g_iHudColor, g_fHudPos, 3.0, 255);
-	}
+		SendHudMsg(iClient, g_sHUDTextSave, g_iDisplayType, INVALID_HANDLE, g_iHudColor, g_fHudPos, 3.0, 255);
 }
 
 // ######## ##     ## ##    ##  ######  ######## ####  #######  ##    ##  ######

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -28,7 +28,8 @@ ConVar g_cVHudTimeout, g_cvHUDChannel;
 ConVar g_cVIgnoreFakeClients;
 ConVar g_cVHudHealthPercentageSquares;
 
-Handle g_hShowHealth = INVALID_HANDLE;
+Cookie g_cShowHealth;
+
 Handle g_hHudSync = INVALID_HANDLE, g_hHudTopHitsSync = INVALID_HANDLE, g_hTimerHudMsgAll = INVALID_HANDLE;
 
 StringMap g_smBossMap = null;
@@ -83,7 +84,7 @@ public void OnPluginStart()
 {
 	LoadTranslations("BossHUD.phrases");
 
-	g_hShowHealth = RegClientCookie("bhud_showhealth", "Enabled/Disable show health", CookieAccess_Private);
+	g_cShowHealth = new Cookie("bhud_showhealth", "Toggle boss health display", CookieAccess_Private);
 
 	SetCookieMenuItem(CookieMenu_BHud, INVALID_HANDLE, "BHud Settings");
 
@@ -658,15 +659,15 @@ public void GetConVars()
 public void ReadClientCookies(int client)
 {
 	char sValue[8];
-	GetClientCookie(client, g_hShowHealth, sValue, sizeof(sValue));
-	g_bShowHealth[client] = (sValue[0] == '\0' ? true : StringToInt(sValue) == 1);
+	g_cShowHealth.Get(client, sValue, sizeof(sValue));
+	g_bShowHealth[client] = (sValue[0] == '\0' ? true : view_as<bool>(StringToInt(sValue)));
 }
 
 public void SetClientCookies(int client)
 {
 	char sValue[8];
 	FormatEx(sValue, sizeof(sValue), "%i", g_bShowHealth[client]);
-	SetClientCookie(client, g_hShowHealth, sValue);
+	g_cShowHealth.Set(client, sValue);
 }
 
 bool CEntityRemove(int entity)
@@ -789,7 +790,7 @@ void Cleanup(bool bPluginEnd = false)
 
 	if (bPluginEnd)
 	{
-		delete g_hShowHealth;
+		delete g_cShowHealth;
 		delete g_cVHudPosition;
 		delete g_cVHudColor;
 		delete g_cVHudSymbols;

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -21,7 +21,7 @@ ConVar g_cVTopHitsPos, g_cVTopHitsColor, g_cVTopHitsTitle, g_cVPlayersInTable;
 ConVar g_cVStatsReward, g_cVBossHitMoney;
 ConVar g_cVHudMinHealth, g_cVHudMaxHealth;
 ConVar g_cVHudTimeout, g_cvHUDChannel;
-ConVar g_cVIgnoreFakeClients, g_cVShowDamagePlayers;
+ConVar g_cVIgnoreFakeClients;
 ConVar g_cVHudHealthPercentageSquares;
 
 Handle g_hShowDmg = INVALID_HANDLE, g_hShowHealth = INVALID_HANDLE;
@@ -119,7 +119,6 @@ public void OnPluginStart()
 	g_cVBossHitMoney = CreateConVar("sm_bhud_tophits_money", "1", "Enable/Disable payment of boss hits", _, true, 0.0, true, 1.0);
 	g_cVStatsReward = CreateConVar("sm_bhud_tophits_reward", "0", "Enable/Disable give of the stats points.", _, true, 0.0, true, 1.0);
 	g_cVIgnoreFakeClients = CreateConVar("sm_bhud_ignore_fakeclients", "1", "Enable/Disable not filtering fake clients.", _, true, 0.0, true, 1.0);
-	g_cVShowDamagePlayers = CreateConVar("sm_bhud_showdamage_players", "1", "Enable/Disable showing damage to players.", _, true, 0.0, true, 1.0);
 
 	g_cVHudHealthPercentageSquares.AddChangeHook(OnConVarChange);
 	g_cVHudMinHealth.AddChangeHook(OnConVarChange);
@@ -137,7 +136,6 @@ public void OnPluginStart()
 	g_cVBossHitMoney.AddChangeHook(OnConVarChange);
 	g_cVStatsReward.AddChangeHook(OnConVarChange);
 	g_cVIgnoreFakeClients.AddChangeHook(OnConVarChange);
-	g_cVShowDamagePlayers.AddChangeHook(OnConVarChange);
 
 	AutoExecConfig(true);
 	GetConVars();

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -158,7 +158,7 @@ public void OnPluginStart()
 	{
 		for (int i = 1; i <= MaxClients; i++)
 		{
-			if(IsClientConnected(i))
+			if (IsClientConnected(i))
 			{
 				OnClientPutInServer(i);
 			}
@@ -190,7 +190,7 @@ public void OnPluginEnd()
 	{
 		for (int i = 1; i <= MaxClients; i++)
 		{
-			if(IsClientConnected(i))
+			if (IsClientConnected(i))
 			{
 				OnClientDisconnect(i);
 			}
@@ -211,8 +211,8 @@ public void OnClientDisconnect(int client)
 	SetClientCookies(client);
 }
 
-public void Event_OnRoundEnd(Handle event, const char[] name, bool dontBroadcast) 
-{ 
+public void Event_OnRoundEnd(Handle event, const char[] name, bool dontBroadcast)
+{
 	CleanupAndInit();
 }
 
@@ -232,15 +232,15 @@ public void Event_PlayerHurt(Event event, const char[] name, bool dontBroadcast)
 	int dmg = -GetEventInt(event, "dmg_health");
 	int hp = GetEventInt(event, "health") + dmg;
 
-	if(g_bShowHealth[attacker])
+	if (g_bShowHealth[attacker])
 	{
 		char szMessage[128] = "Dead";
-		if(hp > 0)
+		if (hp > 0)
 			IntToString(hp, szMessage, sizeof(szMessage));
 		Format(szMessage, sizeof(szMessage), "%N: %s", client, szMessage);
 		SendHudMsg(attacker, szMessage, g_iDisplayType);
 	}
-	if(g_bShowDmg[attacker])
+	if (g_bShowDmg[attacker])
 	{
 		char szMessage[128];
 		Format(szMessage, sizeof(szMessage), "%i HP", dmg);
@@ -305,12 +305,12 @@ public int MenuHandler_BHud(Menu menu, MenuAction action, int param1, int param2
 	{
 		case MenuAction_End:
 		{
-			if(param1 != MenuEnd_Selected)
+			if (param1 != MenuEnd_Selected)
 				delete menu;
 		}
 		case MenuAction_Cancel:
 		{
-			if(param2 == MenuCancel_ExitBack)
+			if (param2 == MenuCancel_ExitBack)
 				ShowCookieMenu(param1);
 		}
 		case MenuAction_Select:
@@ -350,13 +350,13 @@ public int MenuHandler_BHud(Menu menu, MenuAction action, int param1, int param2
 }
 
 
-// ##     ##  #######   #######  ##    ##  ######  
-// ##     ## ##     ## ##     ## ##   ##  ##    ## 
-// ##     ## ##     ## ##     ## ##  ##   ##       
-// ######### ##     ## ##     ## #####     ######  
-// ##     ## ##     ## ##     ## ##  ##         ## 
-// ##     ## ##     ## ##     ## ##   ##  ##    ## 
-// ##     ##  #######   #######  ##    ##  ######  
+// ##     ##  #######   #######  ##    ##  ######
+// ##     ## ##     ## ##     ## ##   ##  ##    ##
+// ##     ## ##     ## ##     ## ##  ##   ##
+// ######### ##     ## ##     ## #####     ######
+// ##     ## ##     ## ##     ## ##  ##         ##
+// ##     ## ##     ## ##     ## ##   ##  ##    ##
+// ##     ##  #######   #######  ##    ##  ######
 
 public void Hook_OnDamage(const char[] output, int caller, int activator, float delay)
 {
@@ -401,7 +401,7 @@ public void Hook_OnDamage(const char[] output, int caller, int activator, float 
 			iHits[activator]++;
 		}
 
-		if(g_bBossHitMoney)
+		if (g_bBossHitMoney)
 		{
 			int cash = GetClientMoney(activator);
 			SetClientMoney(activator, ++cash);
@@ -486,7 +486,7 @@ public void BossHP_OnBossProcessed(CBoss _Boss, bool bHealthChanged, bool bShow)
 	if (fTimeout < 0.0 || fGameTime - fLastChange < fTimeout)
 	{
 		char sFormat[MAX_TEXT_LENGTH];
-		if(g_sHUDText[0])
+		if (g_sHUDText[0])
 		{
 			sFormat[0] = '\n';
 			_Config.GetName(sFormat[1], sizeof(sFormat) - 1);
@@ -627,12 +627,12 @@ public void LagReducer_OnClientGameFrame(int iClient)
 	}
 }
 
-// ######## ##     ## ##    ##  ######  ######## ####  #######  ##    ##  ######  
-// ##       ##     ## ###   ## ##    ##    ##     ##  ##     ## ###   ## ##    ## 
-// ##       ##     ## ####  ## ##          ##     ##  ##     ## ####  ## ##       
-// ######   ##     ## ## ## ## ##          ##     ##  ##     ## ## ## ##  ######  
-// ##       ##     ## ##  #### ##          ##     ##  ##     ## ##  ####       ## 
-// ##       ##     ## ##   ### ##    ##    ##     ##  ##     ## ##   ### ##    ## 
+// ######## ##     ## ##    ##  ######  ######## ####  #######  ##    ##  ######
+// ##       ##     ## ###   ## ##    ##    ##     ##  ##     ## ###   ## ##    ##
+// ##       ##     ## ####  ## ##          ##     ##  ##     ## ####  ## ##
+// ######   ##     ## ## ## ## ##          ##     ##  ##     ## ## ## ##  ######
+// ##       ##     ## ##  #### ##          ##     ##  ##     ## ##  ####       ##
+// ##       ##     ## ##   ### ##    ##    ##     ##  ##     ## ##   ### ##    ##
 // ##        #######  ##    ##  ######     ##    ####  #######  ##    ##  ######
 
 public void CreateHPIconPercent(int hpPercent, int squareCount, char[] sText, int iSize)
@@ -789,7 +789,7 @@ void ProcessEntitySpawned(int entity)
 
 void ProcessEntityDestroyed(int entity)
 {
-	if(IsValidEntity(entity))
+	if (IsValidEntity(entity))
 	{
 		char szName[64];
 		GetEntityName(entity, szName);
@@ -1022,7 +1022,7 @@ void SendHudMsg(
 	int iTransparency = 255
 )
 {
-	if(type == DISPLAY_GAME)
+	if (type == DISPLAY_GAME)
 	{
 		if (hHudSync == INVALID_HANDLE && g_hHudSync != INVALID_HANDLE)
 			hHudSync = g_hHudSync;
@@ -1102,14 +1102,14 @@ stock void PrintHintTextRGB(int client, const char[] format, any ...)
 	VFormat(buff, sizeof(buff), format, 3);
 	FormatEx(buff, sizeof(buff), "</font>%s ", buff);
 
-	for(int i = strlen(buff); i < sizeof(buff); i++)
+	for (int i = strlen(buff); i < sizeof(buff); i++)
 	{
 		buff[i] = ' ';
 	}
 
 	Handle hMessage = StartMessageOne("TextMsg", client, USERMSG_RELIABLE);
-	
-	if(hMessage != INVALID_HANDLE)
+
+	if (hMessage != INVALID_HANDLE)
 	{
 		PbSetInt(hMessage, "msg_dst", 4);
 		PbAddString(hMessage, "params", "#SFUI_ContractKillStart");
@@ -1118,7 +1118,7 @@ stock void PrintHintTextRGB(int client, const char[] format, any ...)
 		PbAddString(hMessage, "params", NULL_STRING);
 		PbAddString(hMessage, "params", NULL_STRING);
 		PbAddString(hMessage, "params", NULL_STRING);
-		
+
 		EndMessage();
 	}
 }
@@ -1127,17 +1127,17 @@ public void BuildName(CBoss boss, char[] szName, int maxlen)
 {
 	CConfig config = boss.dConfig;
 	config.GetName(szName, maxlen);
-	if(config.IsBreakable)
+	if (config.IsBreakable)
 	{
 		CBossBreakable _boss = view_as<CBossBreakable>(boss);
 		FormatEx(szName, maxlen, "%s%i", szName, _boss.iBreakableEnt);
 	}
-	else if(config.IsCounter)
+	else if (config.IsCounter)
 	{
 		CBossCounter _boss = view_as<CBossCounter>(boss);
 		FormatEx(szName, maxlen, "%s%i", szName, _boss.iCounterEnt);
 	}
-	else if(config.IsHPBar)
+	else if (config.IsHPBar)
 	{
 		CBossHPBar _boss = view_as<CBossHPBar>(boss);
 		FormatEx(szName, maxlen, "%s%i", szName, _boss.iBackupEnt);
@@ -1207,7 +1207,7 @@ public void BuildMessage(CBoss boss, bool IsBreakable, int[] TopHits, int tophit
 		StringToUpperCase(sTitle);
 		StringToUpperCase(sDamageUpper);
 		StringToUpperCase(sHitsUpper);
-	
+
 		FormatEx(szMessage, len, "%s %s [%s]\n", sTitle, IsBreakable ? sDamageUpper : sHitsUpper, szName);
 	}
 	else
@@ -1234,14 +1234,14 @@ public void BuildMessage(CBoss boss, bool IsBreakable, int[] TopHits, int tophit
 
 public int GetClientMoney(int client)
 {
-	if(IsValidClient(client))
+	if (IsValidClient(client))
 		return GetEntProp(client, Prop_Send, "m_iAccount");
 	return -1;
 }
 
 public bool SetClientMoney(int client, int money)
 {
-	if(IsValidClient(client))
+	if (IsValidClient(client))
 	{
 		SetEntProp(client, Prop_Send, "m_iAccount", money);
 		return true;
@@ -1251,10 +1251,10 @@ public bool SetClientMoney(int client, int money)
 
 stock void StringToUpperCase(char[] input)
 {
-    for (int i = 0; i < strlen(input); i++)
-    {
-        input[i] = CharToUpper(input[i]);
-    }
+	for (int i = 0; i < strlen(input); i++)
+	{
+		input[i] = CharToUpper(input[i]);
+	}
 }
 
 bool IsValidClient(int client, bool nobots = true)
@@ -1320,7 +1320,7 @@ public Action Command_CHP(int client, int argc)
 
 public Action Command_SHP(int client, int argc)
 {
-	if(!IsValidEntity(g_iEntityId[client]))
+	if (!IsValidEntity(g_iEntityId[client]))
 	{
 		CPrintToChat(client, "{green}[SM]{default} %T", "Invalid Entity", client, g_iEntityId[client]);
 		return Plugin_Handled;
@@ -1346,7 +1346,7 @@ public Action Command_SHP(int client, int argc)
 
 public Action Command_AHP(int client, int argc)
 {
-	if(!IsValidEntity(g_iEntityId[client]))
+	if (!IsValidEntity(g_iEntityId[client]))
 	{
 		CPrintToChat(client, "{green}[SM]{default} %T", "Invalid Entity", client, g_iEntityId[client]);
 		return Plugin_Handled;

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -26,7 +26,6 @@ ConVar g_cVStatsReward, g_cVBossHitMoney;
 ConVar g_cVHudMinHealth, g_cVHudMaxHealth;
 ConVar g_cVHudTimeout, g_cvHUDChannel;
 ConVar g_cVIgnoreFakeClients;
-ConVar g_cVHudHealthPercentageSquares;
 
 Cookie g_cShowHealth;
 
@@ -60,7 +59,6 @@ float g_fTimeout = 0.5;
 
 int g_iMinHealthDetect = 1000;
 int g_iMaxHealthDetect = 100000;
-int g_iSquareCount = 0;
 int g_iHUDChannel = 1;
 int g_iPlayersInTable = 3;
 
@@ -105,7 +103,6 @@ public void OnPluginStart()
 	g_cVHudPosition = CreateConVar("sm_bhud_position", "-1.0 0.09", "The X and Y position for the hud.");
 	g_cVHudColor = CreateConVar("sm_bhud_color", "255 0 0", "RGB color value for the hud.");
 	g_cVHudSymbols = CreateConVar("sm_bhud_symbols", "0", "Determines whether >> and << are wrapped around the text.", _, true, 0.0, true, 1.0);
-	g_cVHudHealthPercentageSquares = CreateConVar("sm_bhud_health_percentage_squares", "0", "Determines how much squares are displayed base on health percentage.", _, true, 0.0, true, 100.0);
 	g_cVDisplayType = CreateConVar("sm_bhud_displaytype", "2", "Display type of HUD. (0 = center, 1 = game, 2 = hint)", _, true, 0.0, true, 2.0);
 	g_cVHudMinHealth = CreateConVar("sm_bhud_health_min", "1000", "Determines what minimum hp entities should have to be detected.", _, true, 0.0, true, 1000000.0);
 	g_cVHudMaxHealth = CreateConVar("sm_bhud_health_max", "100000", "Determines what maximum hp entities should have to be detected.", _, true, 0.0, true, 1000000.0);
@@ -120,7 +117,6 @@ public void OnPluginStart()
 	g_cVStatsReward = CreateConVar("sm_bhud_tophits_reward", "0", "Enable/Disable give of the stats points.", _, true, 0.0, true, 1.0);
 	g_cVIgnoreFakeClients = CreateConVar("sm_bhud_ignore_fakeclients", "1", "Enable/Disable not filtering fake clients.", _, true, 0.0, true, 1.0);
 
-	g_cVHudHealthPercentageSquares.AddChangeHook(OnConVarChange);
 	g_cVHudMinHealth.AddChangeHook(OnConVarChange);
 	g_cVHudMaxHealth.AddChangeHook(OnConVarChange);
 	g_cVHudPosition.AddChangeHook(OnConVarChange);
@@ -406,14 +402,7 @@ public void BossHP_OnBossProcessed(CBoss _Boss, bool bHealthChanged, bool bShow)
 		if (iHPPercentage > 100) iHPPercentage = 100;
 		if (iHPPercentage <= 0) iHPPercentage = 0;
 
-		if (g_iSquareCount > 1)
-		{
-			char sPercentText[MAX_TEXT_LENGTH];
-			CreateHPIconPercent(iHPPercentage, g_iSquareCount, sPercentText, MAX_TEXT_LENGTH);
-			FormatLen += StrCat(sFormat, sizeof(sFormat), sPercentText);
-		}
-		else
-			FormatLen += IntToString(iHealth, sFormat[FormatLen], sizeof(sFormat) - FormatLen);
+		FormatLen += IntToString(iHealth, sFormat[FormatLen], sizeof(sFormat) - FormatLen);
 
 		char sFormatTemp[256], sFormatFinal[256];
 		FormatEx(sFormatTemp, sizeof(sFormatTemp), "[%dPERCENTAGE]", iHPPercentage);
@@ -532,26 +521,6 @@ public void LagReducer_OnClientGameFrame(int iClient)
 // ##       ##     ## ##   ### ##    ##    ##     ##  ##     ## ##   ### ##    ##
 // ##        #######  ##    ##  ######     ##    ####  #######  ##    ##  ######
 
-public void CreateHPIconPercent(int hpPercent, int squareCount, char[] sText, int iSize)
-{
-	if (squareCount <= 1)
-		return;
-
-	int i = 0;
-	int howMuchHealthPerSquare = 100 / squareCount;
-	while (i < squareCount)
-	{
-		if (hpPercent > 0)
-		{
-			StrCat(sText, iSize, "⬛");
-			hpPercent = hpPercent - howMuchHealthPerSquare;
-		}
-		else
-			StrCat(sText, iSize, "⬜");
-		i++;
-	}
-}
-
 public void ColorStringToArray(const char[] sColorString, int aColor[3])
 {
 	char asColors[4][4];
@@ -593,7 +562,6 @@ public void GetConVars()
 
 	g_iMinHealthDetect = g_cVHudMinHealth.IntValue;
 	g_iMaxHealthDetect = g_cVHudMaxHealth.IntValue;
-	g_iSquareCount = g_cVHudHealthPercentageSquares.IntValue;
 	g_iHUDChannel = g_cvHUDChannel.IntValue;
 	g_bTopHitsTitle = g_cVTopHitsTitle.BoolValue;
 	g_iPlayersInTable = g_cVPlayersInTable.IntValue;

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -50,7 +50,6 @@ float g_fHudPos[2], g_fTopHitsPos[2];
 
 bool g_bLate = false;
 bool g_bIsCSGO = false;
-bool g_bDynamicChannels = false;
 
 char g_sHUDText[256];
 char g_sHUDTextSave[256];
@@ -164,23 +163,6 @@ public void OnPluginStart()
 			}
 		}
 	}
-}
-
-public void OnAllPluginsLoaded()
-{
-	g_bDynamicChannels = LibraryExists("DynamicChannels");
-}
-
-public void OnLibraryAdded(const char[] name)
-{
-	if (strcmp(name, "DynamicChannels", false) == 0)
-		g_bDynamicChannels = true;
-}
-
-public void OnLibraryRemoved(const char[] name)
-{
-	if (strcmp(name, "DynamicChannels", false) == 0)
-		g_bDynamicChannels = false;
 }
 
 public void OnPluginEnd()
@@ -1039,13 +1021,6 @@ void SendHudMsg(
 
 			if (g_iHUDChannel < 0 || g_iHUDChannel > 6)
 				g_iHUDChannel = 1;
-
-			bDynamicAvailable = g_bDynamicChannels && CanTestFeatures() && GetFeatureStatus(FeatureType_Native, "GetDynamicChannel") == FeatureStatus_Available;
-
-		#if defined _DynamicChannels_included_
-			if (bDynamicAvailable)
-				iHUDChannel = GetDynamicChannel(g_iHUDChannel);
-		#endif
 
 			if (bDynamicAvailable)
 				ShowHudText(client, iHUDChannel, "%s", szMessageFinale);

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -37,7 +37,6 @@ bool g_bTopHitsTitle = true;
 bool g_bBossHitMoney = true;
 bool g_bStatsReward = false;
 bool g_bIgnoreFakeClients = true;
-bool g_bShowDamagePlayers = true;
 
 int g_iEntityId[MAXPLAYERS+1] = { -1, ... };
 int g_iHudColor[3], g_iTopHitsColor[3];
@@ -93,7 +92,6 @@ public void OnPluginStart()
 	HookEntityOutput("func_breakable", "OnHealthChanged", Hook_OnDamage);
 	HookEntityOutput("math_counter", "OutValue", Hook_OnDamage);
 
-	HookEvent("player_hurt", Event_PlayerHurt, EventHookMode_Pre);
 	HookEvent("round_end", Event_OnRoundEnd, EventHookMode_PostNoCopy);
 
 	g_cVHudPosition = CreateConVar("sm_bhud_position", "-1.0 0.09", "The X and Y position for the hud.");
@@ -182,38 +180,6 @@ public void OnClientDisconnect(int client)
 public void Event_OnRoundEnd(Handle event, const char[] name, bool dontBroadcast)
 {
 	CleanupAndInit();
-}
-
-public void Event_PlayerHurt(Event event, const char[] name, bool dontBroadcast)
-{
-	if (!g_bShowDamagePlayers)
-		return;
-
-	int client = GetClientOfUserId(GetEventInt(event, "userid"));
-	if (!IsValidClient(client, g_bIgnoreFakeClients) || GetClientTeam(client) != CS_TEAM_T)
-		return;
-
-	int attacker = GetClientOfUserId(GetEventInt(event, "attacker"));
-	if (!IsValidClient(attacker, g_bIgnoreFakeClients))
-		return;
-
-	int dmg = -GetEventInt(event, "dmg_health");
-	int hp = GetEventInt(event, "health") + dmg;
-
-	if (g_bShowHealth[attacker])
-	{
-		char szMessage[128] = "Dead";
-		if (hp > 0)
-			IntToString(hp, szMessage, sizeof(szMessage));
-		Format(szMessage, sizeof(szMessage), "%N: %s", client, szMessage);
-		SendHudMsg(attacker, szMessage, g_iDisplayType);
-	}
-	if (g_bShowDmg[attacker])
-	{
-		char szMessage[128];
-		Format(szMessage, sizeof(szMessage), "%i HP", dmg);
-		SendHudMsg(attacker, szMessage);
-	}
 }
 
 public void OnConVarChange(ConVar convar, char[] oldValue, char[] newValue)
@@ -671,8 +637,6 @@ public void GetConVars()
 	g_bBossHitMoney = g_cVBossHitMoney.BoolValue;
 	g_bStatsReward = g_cVStatsReward.BoolValue;
 	g_bIgnoreFakeClients = g_cVIgnoreFakeClients.BoolValue;
-	g_bShowDamagePlayers = g_cVShowDamagePlayers.BoolValue;
-
 }
 
 public void ReadClientCookies(int client)

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -86,16 +86,14 @@ public void OnPluginStart()
 
 	g_cShowHealth = new Cookie("bhud_showhealth", "Toggle boss health display", CookieAccess_Private);
 
-	SetCookieMenuItem(CookieMenu_BHud, INVALID_HANDLE, "BHud Settings");
+	SetCookieMenuItem(CookieMenu_BHud, INVALID_HANDLE, "BossHUD Settings");
 
-	RegConsoleCmd("sm_bhud", Command_BHud, "Toggle BHud");
+	RegConsoleCmd("sm_bhud", Command_BHud, "Toggle boss health display");
+	RegConsoleCmd("sm_bosshud", Command_BHud, "Toggle boss health display");
 
 	RegAdminCmd("sm_currenthp", Command_CHP, ADMFLAG_GENERIC, "See Current HP");
 	RegAdminCmd("sm_subtracthp", Command_SHP, ADMFLAG_GENERIC, "Subtract Current HP");
 	RegAdminCmd("sm_addhp", Command_AHP, ADMFLAG_GENERIC, "Add Current HP");
-
-	RegConsoleCmd("sm_showhealth", Command_ShowHealth, "Toggle seeing boss health");
-	RegConsoleCmd("sm_showhp", Command_ShowHealth, "Toggle seeing boss health");
 
 	HookEntityOutput("func_physbox", "OnHealthChanged", Hook_OnDamage);
 	HookEntityOutput("func_physbox_multiplayer", "OnHealthChanged", Hook_OnDamage);
@@ -236,70 +234,21 @@ public void OnClientCookiesCached(int client)
 //  888   "   888 888        888   Y8888 Y88b. .d88P
 //  888       888 8888888888 888    Y888  "Y88888P"
 
-public void DisplayCookieMenu(int client)
-{
-	Menu menu = new Menu(MenuHandler_BHud, MENU_ACTIONS_DEFAULT | MenuAction_DisplayItem);
-	menu.ExitBackButton = true;
-	menu.ExitButton = true;
-	SetMenuTitle(menu, "Bhud Settings");
-	AddMenuItem(menu, NULL_STRING, "Show damage ");
-	AddMenuItem(menu, NULL_STRING, "Show health ");
-	DisplayMenu(menu, client, MENU_TIME_FOREVER);
-}
-
 public void CookieMenu_BHud(int client, CookieMenuAction action, any info, char[] buffer, int maxlen)
 {
-	switch(action)
+	switch (action)
 	{
+		case CookieMenuAction_DisplayOption:
+		{
+			FormatEx(buffer, maxlen, "Display boss health: %s", g_bShowHealth[client] ? "Enabled" : "Disabled");
+		}
 		case CookieMenuAction_SelectOption:
 		{
-			DisplayCookieMenu(client);
+			ToggleBhud(client);
+			ShowCookieMenu(client);
 		}
 	}
 }
-
-public int MenuHandler_BHud(Menu menu, MenuAction action, int param1, int param2)
-{
-	switch(action)
-	{
-		case MenuAction_End:
-		{
-			if (param1 != MenuEnd_Selected)
-				delete menu;
-		}
-		case MenuAction_Cancel:
-		{
-			if (param2 == MenuCancel_ExitBack)
-				ShowCookieMenu(param1);
-		}
-		case MenuAction_Select:
-		{
-			switch(param2)
-			{
-				case 0:
-				{
-					g_bShowHealth[param1] = !g_bShowHealth[param1];
-				}
-				default:return 0;
-			}
-			DisplayMenu(menu, param1, MENU_TIME_FOREVER);
-		}
-		case MenuAction_DisplayItem:
-		{
-			char buffer[32];
-			switch(param2)
-			{
-				case 0:
-				{
-					FormatEx(buffer, sizeof(buffer), "Show health: %s", (g_bShowHealth[param1]) ? "Enabled":"Disabled");
-				}
-			}
-			return RedrawMenuItem(buffer);
-		}
-	}
-	return 0;
-}
-
 
 // ##     ##  #######   #######  ##    ##  ######
 // ##     ## ##     ## ##     ## ##   ##  ##    ##
@@ -665,6 +614,12 @@ public void SetClientCookies(int client)
 	char sValue[8];
 	FormatEx(sValue, sizeof(sValue), "%i", g_bShowHealth[client]);
 	g_cShowHealth.Set(client, sValue);
+}
+
+public void ToggleBhud(int client)
+{
+	g_bShowHealth[client] = !g_bShowHealth[client];
+	CPrintToChat(client, "{green}[SM]{default} %T %s", "Show health has been", client, g_bShowHealth[client] ? "Enabled" : "Disabled");
 }
 
 bool CEntityRemove(int entity)
@@ -1164,14 +1119,7 @@ bool IsValidClient(int client, bool nobots = true)
 
 public Action Command_BHud(int client, int argc)
 {
-	DisplayCookieMenu(client);
-	return Plugin_Handled;
-}
-
-public Action Command_ShowHealth(int client, int args)
-{
-	g_bShowHealth[client] = !g_bShowHealth[client];
-	CPrintToChat(client, "{green}[SM]{default} %T %s", "Show health has been", client, g_bShowHealth[client] ? "Enabled" : "Disabled");
+	ToggleBhud(client);
 	return Plugin_Handled;
 }
 

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -28,13 +28,12 @@ ConVar g_cVHudTimeout, g_cvHUDChannel;
 ConVar g_cVIgnoreFakeClients;
 ConVar g_cVHudHealthPercentageSquares;
 
-Handle g_hShowDmg = INVALID_HANDLE, g_hShowHealth = INVALID_HANDLE;
+Handle g_hShowHealth = INVALID_HANDLE;
 Handle g_hHudSync = INVALID_HANDLE, g_hHudTopHitsSync = INVALID_HANDLE, g_hTimerHudMsgAll = INVALID_HANDLE;
 
 StringMap g_smBossMap = null;
 ArrayList g_aEntity = null;
 
-bool g_bShowDmg[MAXPLAYERS + 1] =  { true, ... };
 bool g_bShowHealth[MAXPLAYERS + 1] =  { true, ... };
 bool g_bHudSymbols;
 bool g_bTopHitsTitle = true;
@@ -84,7 +83,6 @@ public void OnPluginStart()
 {
 	LoadTranslations("BossHUD.phrases");
 
-	g_hShowDmg = RegClientCookie("bhud_showdamage", "Enable/Disable show damage", CookieAccess_Private);
 	g_hShowHealth = RegClientCookie("bhud_showhealth", "Enabled/Disable show health", CookieAccess_Private);
 
 	SetCookieMenuItem(CookieMenu_BHud, INVALID_HANDLE, "BHud Settings");
@@ -95,8 +93,6 @@ public void OnPluginStart()
 	RegAdminCmd("sm_subtracthp", Command_SHP, ADMFLAG_GENERIC, "Subtract Current HP");
 	RegAdminCmd("sm_addhp", Command_AHP, ADMFLAG_GENERIC, "Add Current HP");
 
-	RegConsoleCmd("sm_showdamage", Command_ShowDamage, "Toggle seeing boss damages inflicted");
-	RegConsoleCmd("sm_showdmg", Command_ShowDamage, "Toggle seeing boss damages inflicted");
 	RegConsoleCmd("sm_showhealth", Command_ShowHealth, "Toggle seeing boss health");
 	RegConsoleCmd("sm_showhp", Command_ShowHealth, "Toggle seeing boss health");
 
@@ -281,10 +277,6 @@ public int MenuHandler_BHud(Menu menu, MenuAction action, int param1, int param2
 			{
 				case 0:
 				{
-					g_bShowDmg[param1] = !g_bShowDmg[param1];
-				}
-				case 1:
-				{
 					g_bShowHealth[param1] = !g_bShowHealth[param1];
 				}
 				default:return 0;
@@ -297,10 +289,6 @@ public int MenuHandler_BHud(Menu menu, MenuAction action, int param1, int param2
 			switch(param2)
 			{
 				case 0:
-				{
-					FormatEx(buffer, sizeof(buffer), "Show damage: %s", (g_bShowDmg[param1]) ? "Enabled":"Disabled");
-				}
-				case 1:
 				{
 					FormatEx(buffer, sizeof(buffer), "Show health: %s", (g_bShowHealth[param1]) ? "Enabled":"Disabled");
 				}
@@ -670,10 +658,6 @@ public void GetConVars()
 public void ReadClientCookies(int client)
 {
 	char sValue[8];
-
-	GetClientCookie(client, g_hShowDmg, sValue, sizeof(sValue));
-	g_bShowDmg[client] = (sValue[0] == '\0' ? true : StringToInt(sValue) == 1);
-
 	GetClientCookie(client, g_hShowHealth, sValue, sizeof(sValue));
 	g_bShowHealth[client] = (sValue[0] == '\0' ? true : StringToInt(sValue) == 1);
 }
@@ -681,10 +665,6 @@ public void ReadClientCookies(int client)
 public void SetClientCookies(int client)
 {
 	char sValue[8];
-
-	FormatEx(sValue, sizeof(sValue), "%i", g_bShowDmg[client]);
-	SetClientCookie(client, g_hShowDmg, sValue);
-
 	FormatEx(sValue, sizeof(sValue), "%i", g_bShowHealth[client]);
 	SetClientCookie(client, g_hShowHealth, sValue);
 }
@@ -809,7 +789,6 @@ void Cleanup(bool bPluginEnd = false)
 
 	if (bPluginEnd)
 	{
-		delete g_hShowDmg;
 		delete g_hShowHealth;
 		delete g_cVHudPosition;
 		delete g_cVHudColor;
@@ -1188,17 +1167,6 @@ bool IsValidClient(int client, bool nobots = true)
 public Action Command_BHud(int client, int argc)
 {
 	DisplayCookieMenu(client);
-	return Plugin_Handled;
-}
-
-public Action Command_ShowDamage(int client, int args)
-{
-	char sEnabled[32], sDisabled[32];
-	FormatEx(sEnabled, sizeof(sEnabled), "%T", "Enabled", client);
-	FormatEx(sDisabled, sizeof(sDisabled), "%T", "Disabled", client);
-
-	g_bShowDmg[client] = !g_bShowDmg[client];
-	CPrintToChat(client, "{green}[SM]{default} %T %s", "Show damage has been", client, g_bShowDmg[client] ? sEnabled : sDisabled);
 	return Plugin_Handled;
 }
 

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -972,8 +972,6 @@ void SendHudMsg(
 			FormatEx(szMessageFinale, sizeof(szMessageFinale), "%s", szMessage);
 			ReplaceString(szMessageFinale,sizeof(szMessageFinale), "PERCENTAGE", "%");
 
-			int iHUDChannel = -1;
-
 			if (g_iHUDChannel < 0 || g_iHUDChannel > 6)
 				g_iHUDChannel = 1;
 

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -154,20 +154,31 @@ public void OnPluginStart()
 public void OnAllPluginsLoaded()
 {
 	g_bDynamicChannels = LibraryExists("DynamicChannels");
+	VerifyNatives();
 }
 
 public void OnLibraryAdded(const char[] name)
 {
 	if (strcmp(name, "DynamicChannels", false) == 0)
+	{
 		g_bDynamicChannels = true;
+		VerifyNatives();
+	}
 }
 
 public void OnLibraryRemoved(const char[] name)
 {
 	if (strcmp(name, "DynamicChannels", false) == 0)
+	{
 		g_bDynamicChannels = false;
+		VerifyNatives();
+	}
 }
 
+stock void VerifyNatives()
+{
+	bDynamicAvailable = g_bDynamicChannels && CanTestFeatures() && GetFeatureStatus(FeatureType_Native, "GetDynamicChannel") == FeatureStatus_Available;
+}
 public void OnPluginEnd()
 {
 	// Late unload
@@ -899,8 +910,6 @@ void SendHudMsg(
 
 			if (g_iHUDChannel < 0 || g_iHUDChannel > 6)
 				g_iHUDChannel = 1;
-
-			bDynamicAvailable = g_bDynamicChannels && CanTestFeatures() && GetFeatureStatus(FeatureType_Native, "GetDynamicChannel") == FeatureStatus_Available;
 
 		#if defined _DynamicChannels_included_
 			if (bDynamicAvailable)

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -972,19 +972,13 @@ void SendHudMsg(
 			FormatEx(szMessageFinale, sizeof(szMessageFinale), "%s", szMessage);
 			ReplaceString(szMessageFinale,sizeof(szMessageFinale), "PERCENTAGE", "%");
 
-			bool bDynamicAvailable = false;
 			int iHUDChannel = -1;
 
 			if (g_iHUDChannel < 0 || g_iHUDChannel > 6)
 				g_iHUDChannel = 1;
 
-			if (bDynamicAvailable)
-				ShowHudText(client, iHUDChannel, "%s", szMessageFinale);
-			else
-			{
-				ClearSyncHud(client, hHudSync);
-				ShowSyncHudText(client, hHudSync, "%s", szMessageFinale);
-			}
+			ClearSyncHud(client, hHudSync);
+			ShowSyncHudText(client, hHudSync, "%s", szMessageFinale);
 		}
 	}
 	else if (type == DISPLAY_HINT && !IsVoteInProgress())

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -43,6 +43,8 @@ int g_iHudColor[3], g_iTopHitsColor[3];
 
 float g_fHudPos[2], g_fTopHitsPos[2];
 
+bool g_bLate = false;
+
 char g_sHUDText[256];
 char g_sHUDTextSave[256];
 
@@ -66,6 +68,12 @@ public Plugin myinfo = {
 	version = "3.6.8",
 	url = "antiteal.com"
 };
+
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
+{
+	g_bLate = late;
+	return APLRes_Success;
+}
 
 public void OnPluginStart()
 {

--- a/addons/sourcemod/scripting/BossHUD.sp
+++ b/addons/sourcemod/scripting/BossHUD.sp
@@ -48,9 +48,6 @@ int g_iHudColor[3], g_iTopHitsColor[3];
 
 float g_fHudPos[2], g_fTopHitsPos[2];
 
-bool g_bLate = false;
-bool g_bIsCSGO = false;
-
 char g_sHUDText[256];
 char g_sHUDTextSave[256];
 
@@ -74,13 +71,6 @@ public Plugin myinfo = {
 	version = "3.6.8",
 	url = "antiteal.com"
 };
-
-public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
-{
-	g_bIsCSGO = (GetEngineVersion() == Engine_CSGO);
-	g_bLate = late;
-	return APLRes_Success;
-}
 
 public void OnPluginStart()
 {
@@ -1033,41 +1023,17 @@ void SendHudMsg(
 	}
 	else if (type == DISPLAY_HINT && !IsVoteInProgress())
 	{
-		if (g_bIsCSGO)
-		{
-			int rgb;
-			rgb |= ((g_iHudColor[0] & 0xFF) << 16);
-			rgb |= ((g_iHudColor[1] & 0xFF) << 8 );
-			rgb |= ((g_iHudColor[2] & 0xFF) << 0 );
-			ReplaceString(szMessage, 256, "\n", "<br/>");
-			PrintHintTextRGB(client, "<font color='#%06X'>%s</font>", rgb, szMessage);
-		}
-		else
-		{
-			char szMessageFinale[512];
-			FormatEx(szMessageFinale, sizeof(szMessageFinale), "%s", szMessage);
-			ReplaceString(szMessageFinale,sizeof(szMessageFinale), "PERCENTAGE", "\%%");
-			PrintHintText(client, "%s", szMessageFinale);
-		}
+		char szMessageFinale[512];
+		FormatEx(szMessageFinale, sizeof(szMessageFinale), "%s", szMessage);
+		ReplaceString(szMessageFinale,sizeof(szMessageFinale), "PERCENTAGE", "\%%");
+		PrintHintText(client, "%s", szMessageFinale);
 	}
 	else
 	{
-		if (g_bIsCSGO)
-		{
-			int rgb;
-			rgb |= ((g_iHudColor[0] & 0xFF) << 16);
-			rgb |= ((g_iHudColor[1] & 0xFF) << 8 );
-			rgb |= ((g_iHudColor[2] & 0xFF) << 0 );
-			ReplaceString(szMessage, 256, "\n", "<br/>");
-			PrintCenterText(client, "<font color='#%06X'>%s</font>", rgb, szMessage);
-		}
-		else
-		{
-			char szMessageFinale[512];
-			FormatEx(szMessageFinale, sizeof(szMessageFinale), "%s", szMessage);
-			ReplaceString(szMessageFinale,sizeof(szMessageFinale), "PERCENTAGE", "\%");
-			PrintCenterText(client, "%s", szMessageFinale);
-		}
+		char szMessageFinale[512];
+		FormatEx(szMessageFinale, sizeof(szMessageFinale), "%s", szMessage);
+		ReplaceString(szMessageFinale,sizeof(szMessageFinale), "PERCENTAGE", "\%");
+		PrintCenterText(client, "%s", szMessageFinale);
 	}
 }
 

--- a/addons/sourcemod/scripting/include/CEntity.inc
+++ b/addons/sourcemod/scripting/include/CEntity.inc
@@ -5,19 +5,19 @@
 
 methodmap CEntity < Basic
 {
-    public CEntity()
-    {
-        Basic myclass = new Basic();
+	public CEntity()
+	{
+		Basic myclass = new Basic();
 
-        myclass.SetInt("iIndex", 0);
-        myclass.SetString("sName", "");
-        myclass.SetInt("iHealth", 0);
-        myclass.SetInt("iMaxHealth", 0);
-        myclass.SetBool("bActive", false);
-        myclass.SetFloat("fLastHitTime", GetGameTime());
+		myclass.SetInt("iIndex", 0);
+		myclass.SetString("sName", "");
+		myclass.SetInt("iHealth", 0);
+		myclass.SetInt("iMaxHealth", 0);
+		myclass.SetBool("bActive", false);
+		myclass.SetFloat("fLastHitTime", GetGameTime());
 
-        return view_as<CEntity>(myclass);
-    }
+		return view_as<CEntity>(myclass);
+	}
 
 
 	public bool GetName(char[] buffer, int length)
@@ -30,28 +30,28 @@ methodmap CEntity < Basic
 		this.SetString("sName", buffer);
 	}
 
-    property int iIndex {
-        public get() { return this.GetInt("iIndex"); }
-        public set(int index) { this.SetInt("iIndex", index); }
-    }
+	property int iIndex {
+		public get() { return this.GetInt("iIndex"); }
+		public set(int index) { this.SetInt("iIndex", index); }
+	}
 
-    property int iHealth {
-        public get() { return this.GetInt("iHealth"); }
-        public set(int health) { this.SetInt("iHealth", health); }
-    }
+	property int iHealth {
+		public get() { return this.GetInt("iHealth"); }
+		public set(int health) { this.SetInt("iHealth", health); }
+	}
 
-    property int iMaxHealth {
-        public get() { return this.GetInt("iMaxHealth"); }
-        public set(int maxhealth) { this.SetInt("iMaxHealth", maxhealth); }
-    }
+	property int iMaxHealth {
+		public get() { return this.GetInt("iMaxHealth"); }
+		public set(int maxhealth) { this.SetInt("iMaxHealth", maxhealth); }
+	}
 
-    property float fLastHitTime {
-        public get() { return this.GetFloat("fLastHitTime"); }
-        public set(float lasthittime) { this.SetFloat("fLastHitTime", lasthittime); }
-    }
+	property float fLastHitTime {
+		public get() { return this.GetFloat("fLastHitTime"); }
+		public set(float lasthittime) { this.SetFloat("fLastHitTime", lasthittime); }
+	}
 
-    property bool bActive {
-        public get() { return this.GetBool("bActive"); }
-        public set(bool active) { this.SetBool("bActive", active); }
-    }
+	property bool bActive {
+		public get() { return this.GetBool("bActive"); }
+		public set(bool active) { this.SetBool("bActive", active); }
+	}
 }

--- a/addons/sourcemod/translations/BossHUD.phrases.txt
+++ b/addons/sourcemod/translations/BossHUD.phrases.txt
@@ -56,14 +56,6 @@
 		"chi"		"停用"
 	}
 
-	"Show damage has been"
-	{
-		"en"		"Show damage has been"
-		"fr"		"Afficher les dégâts a été"
-		"zho"		"顯示對Boss的傷害"
-		"chi"		"显示对Boss的伤害"
-	}
-
 	"Show health has been"
 	{
 		"en"		"Show health has been"


### PR DESCRIPTION
The goal of this pull request is to clean up the plugin and remove unnecessary or unused features. Because CS:GO is now considered legacy and no longer has many active servers, CSGO support was dropped. I am open to discussing and working on the changes. 

Changes in this pull request:
- Fixed inconsistent code formatting and removed trailing whitespace
- Removed CSGO engine check
- Remove `player_hurt` event and all related code
- Reworked settings cookie menu so players can toggle settings directly in the SM cookie menu
- Updated cookie code to use dedicated method maps such as `.Get` and `.Set`
- Removed unused functions
- Removed HP bar display that used emoji/symbols